### PR TITLE
Make sure concat::setup is declared

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -4,6 +4,7 @@
 
 class munin::host {
   package {"munin": ensure => installed, }
+  include concat::setup
 
   Concat::Fragment <<| tag == 'munin' |>>
 


### PR DESCRIPTION
Make sure concat::setup is declared for /etc/munin/munin.conf.
