### PR TITLE
added support for use_ssh for munin 2.0

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -7,6 +7,7 @@ class munin::client(
   $allow = [ '127.0.0.1' ],
   $host = '*',
   $port = '4949',
+  $use_ssh = false,
   $manage_shorewall = false,
   $shorewall_collector_source = 'net'
 ) {

--- a/manifests/client/base.pp
+++ b/manifests/client/base.pp
@@ -20,6 +20,7 @@ class munin::client::base {
       default => $munin::client::host
     },
     port => $munin::client::port,
+    use_ssh => $munin::client::use_ssh,
     config => [ 'use_node_name yes', 'load.load.warning 5', 'load.load.critical 10'],
   }
   include munin::plugins::base

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -1,6 +1,7 @@
 define munin::register (
   $host = $::fqdn,
   $port = '4949',
+  $use_ssh = false,
   $description = 'absent',
   $config = []
 )

--- a/templates/client.erb
+++ b/templates/client.erb
@@ -12,8 +12,12 @@
 # Description: <%= description.gsub!(/\n/, ' ') %>
 <% end -%>
 [<%= fhost.downcase %>]
+<% if use_ssh -%>
+    address ssh://<%= host %>/bin/nc localhost <%= port %>
+<% else -%>
     address <%= host %>
     port <%= port %>
+<% end -%>
 <% if config -%><% config.each do |val| -%> 
     <%= val -%>
 <% end -%><% end -%>


### PR DESCRIPTION
Munin 2.0 allows the host to connect via ssh to the clients. This patch adds a use_ssh option to the munin::client class, that puts the correct ssh line in the configuration file.

The default is set to false, so that it behaves as before.

Managing SSH keys and munin user rights is not part of this patch, bit it can be done with puppet of course. You can use something like:

```
package { "munin-node":
    ensure => installed,
    provider => apt,
}
service { 'munin-node': require => Package['munin-node'] }
ssh_authorized_key { "munin@example.net":
    ensure => present,
    key => "XXX",
    type => "ssh-rsa",
    user => "munin",
    require => Package['munin-node']
}
user { 'munin':
    ensure           => 'present',
    shell            => '/bin/bash',
    require => Package['munin-node']
}
file { "/var/lib/munin/.ssh":
    owner => "munin",
    group => "munin",
    ensure => "directory",
    mode  => 700
}

@@sshkey { $fqdn: type => rsa, key => $sshrsakey, alias => $hostname }
Sshkey <<| |>>


file { "/etc/ssh/ssh_known_hosts":
    mode    => 644,
}
```

I have tested this on ubuntu. Would be glad if someone could test it with other operating systems.
