### PR TITLE
Add support for specifying tags for exported resources

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,7 +9,8 @@ class munin::client(
   $port = '4949',
   $use_ssh = false,
   $manage_shorewall = false,
-  $shorewall_collector_source = 'net'
+  $shorewall_collector_source = 'net',
+  $export_tag = 'munin'
 ) {
   case $::operatingsystem {
     openbsd: { include munin::client::openbsd }

--- a/manifests/client/base.pp
+++ b/manifests/client/base.pp
@@ -15,13 +15,14 @@ class munin::client::base {
     mode => 0644, owner => root, group => 0,
   }
   munin::register { $::fqdn:
-    host => $munin::client::host ? {
-      '*' => $::fqdn,
-      default => $munin::client::host
+    host       => $munin::client::host ? {
+      '*'      => $::fqdn,
+      default  => $munin::client::host
     },
-    port => $munin::client::port,
-    use_ssh => $munin::client::use_ssh,
-    config => [ 'use_node_name yes', 'load.load.warning 5', 'load.load.critical 10'],
+    port       => $munin::client::port,
+    use_ssh    => $munin::client::use_ssh,
+    config     => [ 'use_node_name yes', 'load.load.warning 5', 'load.load.critical 10'],
+    export_tag => $munin::client::export_tag,
   }
   include munin::plugins::base
 }

--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -3,12 +3,13 @@
 # See LICENSE for the full license granted to you.
 
 class munin::host(
-  $cgi_graphing = false
+  $cgi_graphing = false,
+  $export_tag = 'munin'
 ) {
   package {"munin": ensure => installed, }
   include concat::setup
 
-  Concat::Fragment <<| tag == 'munin' |>>
+  Concat::Fragment <<| tag == $export_tag |>>
 
   concat::fragment{'munin.conf.header':
     target => '/etc/munin/munin.conf',

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -3,15 +3,16 @@ define munin::register (
   $port = '4949',
   $use_ssh = false,
   $description = 'absent',
-  $config = []
+  $config = [],
+  $export_tag = 'munin'
 )
 {
   $fhost = $name
   $client_type = 'client'
 
   @@concat::fragment{ "munin_client_${fhost}_${port}":
-    target => '/etc/munin/munin.conf',
+    target  => '/etc/munin/munin.conf',
     content => template("munin/client.erb"),
-    tag => 'munin',
+    tag     => $export_tag,
   }
 }


### PR DESCRIPTION
This enables you to specify different servers for different clients.
