### PR TITLE
Use Facter::Util::Resolution.which instead of `which ...`

### DIFF
--- a/lib/facter/acpi_available.rb
+++ b/lib/facter/acpi_available.rb
@@ -1,7 +1,7 @@
 # return whether acpi is available -- used for deciding whether to install the munin plugin
 Facter.add("acpi_available") do
     setcode do
-    	if not File.exist? `which acpi 2>/dev/null`.chomp or `acpi -t -B -A 2>/dev/null`.match(/\d/).nil?
+    	if not Facter::Util::Resolution.which('acpi') or `acpi -t -B -A 2>/dev/null`.match(/\d/).nil?
     		"absent"
     	else
     		"present"


### PR DESCRIPTION
If this plugin is synced to systems without the 'which' executable, backticked which will cause error messages.
