### PR TITLE
use rather ensure_packages

### DIFF
--- a/manifests/client/debian.pp
+++ b/manifests/client/debian.pp
@@ -1,9 +1,7 @@
 # Install the munin client on debian
 class munin::client::debian inherits munin::client::base {
   # the plugin will need that
-  package { 'iproute':
-    ensure => installed
-  }
+  ensure_packages(['iproute'])
 
   $hasstatus = $::lsbdistcodename ? {
     sarge => false,


### PR DESCRIPTION
Stdlib `ensure_packages` will avoid duplicate resource declaration error, if packages was previously defined
