### PR TITLE
Allow customization of munin client host_name

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -6,7 +6,7 @@
 class munin::client(
   $allow                      = [ '127.0.0.1' ],
   $host                       = '*',
-  $host_name                  = '::fqdn',
+  $host_name                  = $::fqdn,
   $port                       = '4949',
   $use_ssh                    = false,
   $manage_shorewall           = false,

--- a/templates/munin-node.conf.erb
+++ b/templates/munin-node.conf.erb
@@ -34,11 +34,7 @@ ignore_file \.pod$
 # Set this if the client doesn't report the correct hostname when
 # telnetting to localhost, port 4949
 #
-<% if scope.lookupvar('munin::client::host_name') == '::fqdn' -%>
-host_name <%= scope.lookupvar('::fqdn') %>
-<% else -%>
 host_name <%= scope.lookupvar('munin::client::host_name') %>
-<% end -%>
 
 # A list of addresses that are allowed to connect.  This must be a
 # regular expression, since Net::Server does not understand CIDR-style


### PR DESCRIPTION
The munin::client doesn't allow to overwrite host_name, this patch adds a host_name option to the class
