### PR TITLE
Fix an error on system without full UTF-8: invalid byte sequence in US-ASCII

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 # Copyright (C) 2007 David Schmitt <david@schmitt.edv-bus.at>
 #
 # Copyright 2008, Puzzle ITC GmbH
-# Marcel Härry haerry+puppet(at)puzzle.ch
+# Marcel Haerry haerry+puppet(at)puzzle.ch
 # Simon Josi josi+puppet(at)puzzle.ch
 #
 # This program is free software; you can redistribute


### PR DESCRIPTION
For example on OpenBSD with Ruby 2.0 the module fails to apply because of that error.
