### PR TITLE
Use cron resource instead of a cron.d file

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -39,12 +39,12 @@ class munin::host(
   }
 
   # from time to time we cleanup hanging munin-runs
-  file{'/etc/cron.d/munin_kill':
-    content => "4,34 * * * * root if $(ps ax | grep -v grep | grep -q munin-run); then killall munin-run; fi\n",
-    owner   => root,
-    group   => 0,
-    mode    => '0644',
+  cron { 'munin_kill':
+    command => 'if $(ps ax | grep -v grep | grep -q munin-run); then killall munin-run; fi',
+    minute  => ['4', '34'],
+    user    => 'root',
   }
+
   if $munin::host::manage_shorewall {
     include shorewall::rules::out::munin
   }


### PR DESCRIPTION
For example OpenBSD lacks /etc/cron.d and using a native type is recommended anyway.
