### PR TITLE
Fix compatibility with puppetlabs-concat (1.2.1)

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -24,18 +24,18 @@ class munin::host(
     name   => $package,
   }
 
+  concat{ '/etc/munin/munin.conf':
+    owner => root,
+    group => 0,
+    mode  => '0644',
+  }
+
   Concat::Fragment <<| tag == $export_tag |>>
 
   concat::fragment{'munin.conf.header':
     target => '/etc/munin/munin.conf',
     source => $header_source,
     order  => 05,
-  }
-
-  concat{ '/etc/munin/munin.conf':
-    owner => root,
-    group => 0,
-    mode  => '0644',
   }
 
   include munin::plugins::muninhost


### PR DESCRIPTION
Tue to the commit https://github.com/puppetlabs/puppetlabs-concat/commit/e34eac0996dd1b6d376c0a974a0ca090d285888f the module puppetlabs-concat is now sensible to the declaration order of concat resources. Without this change the result is the following:

````
Error: Failed to apply catalog: Could not find filebucket  specified in backup
````