### PR TITLE
pick host/munin.conf.header based on osfamily

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -9,6 +9,7 @@ class munin::host(
   $header_source    = [ "puppet:///modules/site_munin/config/host/${::fqdn}/munin.conf.header",
                 "puppet:///modules/site_munin/config/host/munin.conf.header.${::operatingsystem}.${::operatingsystemmajrelease}",
                 "puppet:///modules/site_munin/config/host/munin.conf.header.${::operatingsystem}",
+                "puppet:///modules/site_munin/config/host/munin.conf.header.${::osfamily}",
                 'puppet:///modules/site_munin/config/host/munin.conf.header',
                 "puppet:///modules/munin/config/host/munin.conf.header.${::operatingsystem}.${::operatingsystemmajrelease}",
                 "puppet:///modules/munin/config/host/munin.conf.header.${::operatingsystem}",


### PR DESCRIPTION
This re-adds support for CloudLinux among other distributions.
Otherwise it would fail with:

`
Error: /Stage[main]/Munin::Host/Concat::Fragment[munin.conf.header]/File[/var/lib/puppet/concat/_etc_munin_munin.conf/fragments/05_munin.conf.header]: Could not evaluate: Could not retrieve information from environment shared_production source(s) puppet:///modules/site_munin/config/host/hostname/munin.conf.header, puppet:///modules/site_munin/config/host/munin.conf.header.CloudLinux.7, puppet:///modules/site_munin/config/host/munin.conf.header.CloudLinux, puppet:///modules/site_munin/config/host/munin.conf.header, puppet:///modules/munin/config/host/munin.conf.header.CloudLinux.7, puppet:///modules/munin/config/host/munin.conf.header.CloudLinux, puppet:///modules/munin/config/host/munin.conf.header
`
