### PR TITLE
pick host/munin.conf.header based on osfamily

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -9,9 +9,11 @@ class munin::host(
   $header_source    = [ "puppet:///modules/site_munin/config/host/${::fqdn}/munin.conf.header",
                 "puppet:///modules/site_munin/config/host/munin.conf.header.${::operatingsystem}.${::operatingsystemmajrelease}",
                 "puppet:///modules/site_munin/config/host/munin.conf.header.${::operatingsystem}",
+                "puppet:///modules/site_munin/config/host/munin.conf.header.${::osfamily}",
                 'puppet:///modules/site_munin/config/host/munin.conf.header',
                 "puppet:///modules/munin/config/host/munin.conf.header.${::operatingsystem}.${::operatingsystemmajrelease}",
                 "puppet:///modules/munin/config/host/munin.conf.header.${::operatingsystem}",
+                "puppet:///modules/munin/config/host/munin.conf.header.${::osfamily}",
                 'puppet:///modules/munin/config/host/munin.conf.header' ],
 ) {
   $package = $::operatingsystem ? {


### PR DESCRIPTION
This would use the RedHat template for CloudLinux, which is
a RedHat derivative.

```
[root@cloudlinux-1 ~]# facter osfamily
RedHat
[root@cloudlinux-1 ~]# facter operatingsystem
CloudLinux
[root@cloudlinux-1 ~]# facter os
{"name"=>"CloudLinux", "family"=>"RedHat", "release"=>{"major"=>"7", "minor"=>"2", "full"=>"7.2"}}
```
